### PR TITLE
Rails動画教材ページの実装

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,0 +1,4 @@
+class MoviesController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,4 +1,5 @@
 class MoviesController < ApplicationController
   def index
+    @movies = Movie.where(genre: ["basic", "git", "ruby", "rails"]).order(id: :asc)
   end
 end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -1,0 +1,12 @@
+module MoviesHelper
+  def embed_youtube(url)
+    tag.iframe(
+      width: 560,
+      height: 315,
+      src: url,
+      frameborder: 0,
+      allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
+      allowfullscreen: true
+      )
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,7 +11,7 @@
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
           <a class="dropdown-item" href="/texts">Ruby/Railsテキスト教材</a>
-          <a class="dropdown-item" href="#">Ruby/Rails動画教材</a>
+          <a class="dropdown-item" href="/movies">Ruby/Rails動画教材</a>
           <a class="dropdown-item" href="/texts">AWSテキスト教材</a>
           <a class="dropdown-item" href="#">よくある質問集</a>
           <a class="dropdown-item" href="#">チャレンジ問題集</a>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,0 +1,20 @@
+<div class="container-fluid">
+  <div class="row">
+    <% @movies.each.with_index(1) do |movie, i| %>
+      <div class="col-12 col-md-6 col-lg-4">
+        <div class="card border-dark mb-3">
+          <div class="card-header p-0">
+            <div class="embed-responsive embed-responsive-16by9">
+              <p><%= embed_youtube(movie.url) %></p>
+            </div>
+          </div>
+          <div class="card-body text-dark movie-body">
+            <p class="card-text movie-title">
+                Lv.<%= i %>:<%= movie.title %>
+            </p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <% @movies.each.with_index(1) do |movie, i| %>
       <div class="col-12 col-md-6 col-lg-4">
-        <div class="card border-dark mb-3">
+        <div class="card border-dark mb-3" style="height: 23rem;">
           <div class="card-header p-0">
             <div class="embed-responsive embed-responsive-16by9">
               <p><%= embed_youtube(movie.url) %></p>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Movies#index</h1>
+<p>Find me in app/views/movies/index.html.erb</p>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,2 +1,2 @@
-<h1>Movies#index</h1>
-<p>Find me in app/views/movies/index.html.erb</p>
+<h1>Rails動画教材</h1>
+<%= embed_youtube("https://www.youtube.com/embed/iFMNUM2Q9mg") %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,4 +1,4 @@
-<div class="mx-auto" style="width: 200px;">
-  <h3>Rails動画教材</h3>
+<div class="contents-title text-center">
+  <h3>Ruby/Rails 動画</h3>
 </div>
 <%= render 'movies/movie', movie: @movie %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,2 +1,4 @@
-<h1>Rails動画教材</h1>
-<%= embed_youtube("https://www.youtube.com/embed/iFMNUM2Q9mg") %>
+<div class="mx-auto" style="width: 200px;">
+  <h3>Rails動画教材</h3>
+</div>
+<%= render 'movies/movie', movie: @movie %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   devise_for :users
   root "texts#index"
   resources :texts
+  resources :movies
 end


### PR DESCRIPTION
## issue 番号
close #28 

## 実装内容
- Rails動画教材の一覧ページを作成
  - 部分テンプレート/views/_movie.html.erbを作成
- Rails動画教材で表示するジャンルは["basic", "git", "ruby", "rails"]
- ナビバーの動画教材ページへのリンクが機能

## 参考資料（必要があれば）
- 動画教材の一覧ページの実装
  - [やんばるエキスパート教材 YouTube動画の投稿](https://www.yanbaru-code.com/texts/349)
  - [やんばるエキスパート Ruby/Rails動画ページ](https://www.yanbaru-code.com/movies)
  - [【公式】Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
  - [【公式】Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)
  - [【Rails基礎】ややこしい部分テンプレートの省略形について簡単にまとめてみた](https://techtechmedia.com/partial-template-rails/)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）
<img width="689" alt="スクリーンショット 2021-05-03 23 30 35" src="https://user-images.githubusercontent.com/77927517/116891108-4be87080-ac69-11eb-97a9-9f1439586093.png">
