### PR TITLE
ゲストログイン機能を実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -53,6 +53,7 @@ body {
 .header-nav {
   font-size: 0.8rem;
   margin: 0 auto;
+  word-break: keep-all;
 }
 
 // フッター

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,10 @@
+class Users::PasswordsController < Devise::PasswordsController
+  before_action :ensure_normal_user, only: :create
+
+  def ensure_normal_user
+    if params[:user][:email].downcase == "guest@example.com"
+      redirect_to new_user_session_path, alert: "ゲストユーザーのパスワード再設定はできません。"
+    end
+  end
+
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,9 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :ensure_normal_user, only: :destroy
+
+  def ensure_normal_user
+    if resource.email == "guest@example.com"
+      redirect_to root_path, alert: "ゲストユーザーは削除できません。"
+    end
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,9 +1,9 @@
 class Users::RegistrationsController < Devise::RegistrationsController
-  before_action :ensure_normal_user, only: :destroy
+  before_action :ensure_normal_user, only: %i[update destroy]
 
   def ensure_normal_user
     if resource.email == "guest@example.com"
-      redirect_to root_path, alert: "ゲストユーザーは削除できません。"
+      redirect_to root_path, alert: "ゲストユーザーの更新・削除は削除できません。"
     end
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,6 @@
+class Users::SessionsController < Devise::SessionsController
+  def guest_sign_in
+    sign_in User.guest
+    redirect_to root_path, notice: "ゲストユーザーとしてログインしました。"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,10 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  def self.guest
+    find_or_create_by!(email: "guest@example.com")
+      user.password = SecureRandom.urlsafe_base64
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   def self.guest
-    find_or_create_by!(email: "guest@example.com")
+    find_or_create_by!(email: "guest@example.com") do |user|
       user.password = SecureRandom.urlsafe_base64
     end
   end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -81,7 +81,7 @@
         </li>
       <% else %>
         <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
-        <%= link_to "ゲストログイン(閲覧用)", users_guest_sign_in_path, method: :post, class: "nav-item nav-link active" %>
+        <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "nav-item nav-link active" %>
         <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
       <% end %>
     </ul>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -81,6 +81,7 @@
         </li>
       <% else %>
         <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
+        <%= link_to "ゲストログイン(閲覧用)", users_guest_sign_in_path, method: :post, class: "nav-item nav-link active" %>
         <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
       <% end %>
     </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   devise_for :users, controllers: {
-    registrations: "users/registrations"
+    registrations: "users/registrations",
+    passwords: "users/passwords"
   }
   root "texts#index"
   resources :texts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: "users/registrations"
+  }
   root "texts#index"
   resources :texts
   resources :movies

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,7 @@ Rails.application.routes.draw do
   root "texts#index"
   resources :texts
   resources :movies
+  devise_scope :user do
+    post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
+  end
 end


### PR DESCRIPTION
## issue 番号

close #48 

## 実装内容
- ゲストログイン機能を実装
  - ゲストログイン処理の実装
  - ヘッダーにゲストログインボタンを設置
  - ゲストユーザーを削除できないようにする
  - ゲストユーザーのメールアドレス・パスワードを変更できないようにする
  - パスワード再設定メールの送信機能を止める
  - ゲストログインのリンク名を変更、単語で改行されるよう設定  

## 参考資料（必要があれば）

- ゲストログイン機能
  - [やんばるエキスパートアプリ](https://www.yanbaru-code.com/texts/392)
  - [簡単ログイン・ゲストログイン機能の実装方法（ポートフォリオ用）](https://qiita.com/take18k_tech/items/35f9b5883f5be4c6e104)
  - [URLの自動改行をなんとかしたいときのCSS](https://worker-training.com/webdesign/css/word-break/)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）
完成版
<img width="500" alt="完成版" src="https://user-images.githubusercontent.com/70443334/123010477-a6948200-d3f9-11eb-823b-bb055c834fad.png">

ゲストユーザーを削除しようとした時
<img width="500" alt="ゲストユーザーを削除" src="https://user-images.githubusercontent.com/70443334/123010600-de9bc500-d3f9-11eb-8134-ad27e226cbe3.png">

パスワードの再設定をしようとした時
<img width="500" alt="パスワード再設定" src="https://user-images.githubusercontent.com/70443334/123010647-f7a47600-d3f9-11eb-9953-40e0824e7d10.png">

改行されてしまい、ヘッダーが分厚くなる→フラッシュに被さってしまう（完成版は`ゲストログイン`にして、単語で改行されるよう設定）
<img width="500" alt="ゲストログイン改行" src="https://user-images.githubusercontent.com/70443334/123010730-26225100-d3fa-11eb-9afa-60703199970f.png">
