### PR TITLE
ransackを用いて動画教材の検索機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'devise-bootstrap-views'
 gem 'coderay'
 gem 'redcarpet'
 gem 'kaminari'
+gem 'ransack'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)
   rails-i18n (~> 6.0)
+  ransack
   redcarpet
   sass-rails (>= 6)
   spring

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,11 +1,8 @@
 class MoviesController < ApplicationController
-  # 1ページに表示される動画教材を定義
-  PER = 8
-
   def index
     @q = Movie.ransack(params[:q])
-    @movies = @q.result.recent.page(params[:page]).per(PER)
+    @movies = @q.result.recent.page(params[:page]).per(Movie::PER)
     page_num = @movies.current_page
-    @base_level = (page_num - 1) * PER
+    @base_level = (page_num - 1) * Movie::PER
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -4,7 +4,7 @@ class MoviesController < ApplicationController
 
   def index
     @q = Movie.ransack(params[:q])
-    @movies = @q.result.where(genre: ["basic", "git", "ruby", "rails"]).includes(:watches).order(id: :asc).recent.page(params[:page]).per(PER)
+    @movies = @q.result.recent.page(params[:page]).per(PER)
     page_num = @movies.current_page
     @base_level = (page_num - 1) * PER
   end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,7 +1,7 @@
 class MoviesController < ApplicationController
   def index
     @q = Movie.ransack(params[:q])
-    @movies = @q.result.recent.page(params[:page]).per(Movie::PER)
+    @movies = @q.result.recent.includes(:watches).page(params[:page]).per(Movie::PER)
     page_num = @movies.current_page
     @base_level = (page_num - 1) * Movie::PER
   end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -3,7 +3,8 @@ class MoviesController < ApplicationController
   PER = 8
 
   def index
-    @movies = Movie.where(genre: ["basic", "git", "ruby", "rails"]).includes(:watches).order(id: :asc).recent.page(params[:page]).per(PER)
+    @q = Movie.ransack(params[:q])
+    @movies = @q.result.where(genre: ["basic", "git", "ruby", "rails"]).includes(:watches).order(id: :asc).recent.page(params[:page]).per(PER)
     page_num = @movies.current_page
     @base_level = (page_num - 1) * PER
   end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,6 +1,5 @@
 class Movie < ApplicationRecord
   has_many :watches, dependent: :destroy
-  
   has_many :watched_users, through: :watches, source: :user
   
   with_options presence: true do
@@ -31,5 +30,9 @@ class Movie < ApplicationRecord
     talk: 14, # 全ての勉強会
     live: 15, # 勉強会
   }
-  scope :recent, -> { where(genre: ["basic", "git", "ruby", "rails"]).includes(:watches).order(id: :asc) }
+  scope :active, -> { where(genre: ["basic", "git", "ruby", "rails"]).order(id: :asc) }
+  scope :include, -> { includes(:watches) }
+  scope :recent, -> { active.include }
+  # 1ページに表示される動画教材を定義
+  PER = 8
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,4 +1,6 @@
 class Movie < ApplicationRecord
+  # 1ページに表示される動画教材を定義
+  PER = 8
   has_many :watches, dependent: :destroy
   has_many :watched_users, through: :watches, source: :user
   
@@ -7,7 +9,7 @@ class Movie < ApplicationRecord
     validates :title
     validates :url
   end
-  #movieをuserが視聴済みにしている時はtrue,していない時はfalse
+  #movieをuserが視聴済みにしている時はtrue,していcdない時はfalse
   def watched_by?(user)
     watches.any?{ |watch| watch.user_id == user.id }
   end
@@ -33,6 +35,4 @@ class Movie < ApplicationRecord
   scope :active, -> { where(genre: ["basic", "git", "ruby", "rails"]).order(id: :asc) }
   scope :include, -> { includes(:watches) }
   scope :recent, -> { active.include }
-  # 1ページに表示される動画教材を定義
-  PER = 8
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -31,5 +31,5 @@ class Movie < ApplicationRecord
     talk: 14, # 全ての勉強会
     live: 15, # 勉強会
   }
-  scope :recent, -> { where(genre: ["basic", "git", "ruby", "rails"]).order(id: :asc) }
+  scope :recent, -> { where(genre: ["basic", "git", "ruby", "rails"]).includes(:watches).order(id: :asc) }
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -9,7 +9,7 @@ class Movie < ApplicationRecord
     validates :title
     validates :url
   end
-  #movieをuserが視聴済みにしている時はtrue,していcdない時はfalse
+  #movieをuserが視聴済みにしている時はtrue,していない時はfalse
   def watched_by?(user)
     watches.any?{ |watch| watch.user_id == user.id }
   end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -32,7 +32,5 @@ class Movie < ApplicationRecord
     talk: 14, # 全ての勉強会
     live: 15, # 勉強会
   }
-  scope :active, -> { where(genre: ["basic", "git", "ruby", "rails"]).order(id: :asc) }
-  scope :include, -> { includes(:watches) }
-  scope :recent, -> { active.include }
+  scope :recent, -> { where(genre: ["basic", "git", "ruby", "rails"]).order(id: :asc) }
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,11 +1,16 @@
-<form class="form-inline justify-content-center">  
-  <%= search_form_for @q do |f| %>
-    <div class="form-group mx-sm-3 mb-2">
-      <%= f.search_field :title_cont, class: "form-control", placeholder: "🔍教材を探す" %>
-    </div>
-    <%= f.submit "検索", class: "btn btn-primary mb-2" %>
-    <%= link_to "戻る", :back, class: "btn btn-secondary mb-2" %>
-  <% end %>
+<form class="form-inline justify-content-center">
+    <%= search_form_for @q do |f| %>
+      <div class="col-3r">
+        <div class="form-group ml-sm-2 mb-2">
+          <%= f.search_field :title_cont, class: "form-control", placeholder: "🔍教材を探す" %>
+        </div>
+      </div>
+      <div class="col-2">
+        <%= f.submit "検索", class: "btn btn-primary mb-2" %>
+        <%= link_to "戻る", :back, class: "btn btn-secondary mb-2" %>
+      </div>
+    <% end %>
+  </div>
 </form>
 <hr>
 <%= render 'movies/movie', movie: @movie %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,9 +1,10 @@
 <form class="form-inline justify-content-center">  
   <%= search_form_for @q do |f| %>
     <div class="form-group mx-sm-3 mb-2">
-      <%= f.search_field :title_cont, class: "form-control", placeholder: "教材を探す" %>
+      <%= f.search_field :title_cont, class: "form-control", placeholder: "🔍教材を探す" %>
     </div>
     <%= f.submit "検索", class: "btn btn-primary mb-2" %>
+    <%= link_to "戻る", :back, class: "btn btn-secondary mb-2" %>
   <% end %>
 </form>
 <hr>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,5 +1,11 @@
 <div class="contents-title text-center">
   <h3>Ruby/Rails 動画</h3>
+  <%= search_form_for @q do |f| %>
+    <%= f.label :title_cont, "タイトル" %>
+    <%= f.search_field :title_cont %>
+    <%= f.submit "検索" %>
+  <% end %>
 </div>
+<hr>
 <%= render 'movies/movie', movie: @movie %>
- <%= paginate @movies %>
+<%= paginate @movies %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,11 +1,11 @@
-<div class="contents-title text-center">
-  <h3>Ruby/Rails 動画</h3>
+<form class="form-inline justify-content-center">  
   <%= search_form_for @q do |f| %>
-    <%= f.label :title_cont, "タイトル" %>
-    <%= f.search_field :title_cont %>
-    <%= f.submit "検索" %>
+    <div class="form-group mx-sm-3 mb-2">
+      <%= f.search_field :title_cont, class: "form-control", placeholder: "教材を探す" %>
+    </div>
+    <%= f.submit "検索", class: "btn btn-primary mb-2" %>
   <% end %>
-</div>
+</form>
 <hr>
 <%= render 'movies/movie', movie: @movie %>
 <%= paginate @movies %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,3 +1,6 @@
+<div class="contents-title text-center">
+  <h3>Ruby/Rails 動画</h3>
+</div>
 <form class="form-inline justify-content-center">
     <%= search_form_for @q do |f| %>
       <div class="col-2.5 align-self-center">

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,7 +1,7 @@
 <form class="form-inline justify-content-center">
     <%= search_form_for @q do |f| %>
-      <div class="col-3r">
-        <div class="form-group ml-sm-2 mb-2">
+      <div class="col-2.5 align-self-center">
+        <div class="form-group mx-sm-3 mb-2">
           <%= f.search_field :title_cont, class: "form-control", placeholder: "🔍教材を探す" %>
         </div>
       </div>


### PR DESCRIPTION
## issue 番号
close #49 

## 実装内容
- 動画教材の検索機能
  - gem 'ransack'を導入
  - タイトル名の部分検索可能

## 参考資料
- 検索機能
  - [やんばるエキスパート](https://www.yanbaru-code.com/texts/221)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）
- タイトル下に検索バー追加(動画教材の一覧ページ)
<img width="1477" alt="スクリーンショット 2021-06-23 17 36 12" src="https://user-images.githubusercontent.com/77927517/123067816-4844bf00-d44c-11eb-92d6-b83d1f6929d4.png">
- 検索後
<img width="1491" alt="スクリーンショット 2021-06-23 17 36 34" src="https://user-images.githubusercontent.com/77927517/123067855-5266bd80-d44c-11eb-849c-e667322f3ac6.png">

## 備考
- オリジナルアプリの教材検索には劣る形での実装となりました
   - 自動検索しない
   - 非同期処理が未実装(空で検索して元の一覧ページに戻る)