### PR TITLE
動画教材一覧ページのcontainerの最大幅を修正

### DIFF
--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -2,13 +2,13 @@
   <div class="row">
     <% @movies.each.with_index(1) do |movie, i| %>
       <div class="col-12 col-md-6 col-lg-4">
-        <div class="card border-dark mb-3" style="height: 23rem;">
+        <div class="card border-dark mb-3">
           <div class="card-header p-0">
             <div class="embed-responsive embed-responsive-16by9">
               <p><%= embed_youtube(movie.url) %></p>
             </div>
           </div>
-          <div class="card-body text-dark movie-body">
+          <div class="card-body text-dark movie-body" style="height: 12rem;">
             <p id="movie-<%= movie.id %>">
               <% if movie.watched_by?(current_user) %>
                 <%= render "watched", movie: movie %>
@@ -17,7 +17,7 @@
               <% end %>
             </p>
             <p class="card-text movie-title">
-                Lv.<%= @base_level + i %>:<%= movie.title %>
+              Lv.<%= @base_level + i %>:<%= movie.title %>
             </p>
           </div>
         </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,20 +1,22 @@
-<div class="contents-title text-center">
-  <h3>Ruby/Rails 動画</h3>
-</div>
-<form class="form-inline justify-content-center">
-    <%= search_form_for @q do |f| %>
-      <div class="col-2.5 align-self-center">
-        <div class="form-group mx-sm-3 mb-2">
-          <%= f.search_field :title_cont, class: "form-control", placeholder: "🔍教材を探す" %>
-        </div>
-      </div>
-      <div class="col-2">
-        <%= f.submit "検索", class: "btn btn-primary mb-2" %>
-        <%= link_to "戻る", :back, class: "btn btn-secondary mb-2" %>
-      </div>
-    <% end %>
+<div class="base-container mw-xl">
+  <div class="contents-title text-center">
+    <h3>Ruby/Rails 動画</h3>
   </div>
-</form>
-<hr>
-<%= render 'movies/movie', movie: @movie %>
-<%= paginate @movies %>
+  <form class="form-inline justify-content-center">
+      <%= search_form_for @q do |f| %>
+        <div class="col-2.5 align-self-center">
+          <div class="form-group mx-sm-3 mb-2">
+            <%= f.search_field :title_cont, class: "form-control", placeholder: "🔍教材を探す" %>
+          </div>
+        </div>
+        <div class="col-2">
+          <%= f.submit "検索", class: "btn btn-primary mb-2" %>
+          <%= link_to "戻る", :back, class: "btn btn-secondary mb-2" %>
+        </div>
+      <% end %>
+    </div>
+  </form>
+  <hr>
+  <%= render 'movies/movie', movie: @movie %>
+  <%= paginate @movies %>
+</div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -12,7 +12,6 @@
         <div class="col-2">
           <%= f.submit "検索", class: "btn btn-primary mb-2" %>
           <%= link_to "戻る", :back, class: "btn btn-secondary mb-2" %>
-        </div>
       <% end %>
     </div>
   </form>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -3,17 +3,19 @@
     <h3>Ruby/Rails 動画</h3>
   </div>
   <form class="form-inline justify-content-center">
-      <%= search_form_for @q do |f| %>
-        <div class="col-2.5 align-self-center">
-          <div class="form-group mx-sm-3 mb-2">
-            <%= f.search_field :title_cont, class: "form-control", placeholder: "🔍教材を探す" %>
-          </div>
+    <%= search_form_for @q do |f| %>
+      <div class="col-2.5 align-self-center">
+        <div class="form-group mx-sm-3 mb-2">
+          <%= f.search_field :title_cont, class: "form-control", placeholder: "🔍教材を探す" %>
         </div>
-        <div class="col-2">
-          <%= f.submit "検索", class: "btn btn-primary mb-2" %>
-          <%= link_to "戻る", :back, class: "btn btn-secondary mb-2" %>
-      <% end %>
-    </div>
+      </div>
+      <table>
+        <tr>
+          <td><%= f.submit "検索", class: "btn btn-primary mb-2" %></td>
+          <td><%= link_to "戻る", :back, class: "btn btn-secondary mb-2" %></td>
+        </tr>
+      </table>
+    <% end %>
   </form>
   <hr>
   <%= render 'movies/movie', movie: @movie %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 2021_05_26_151149) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["movie_id"], name: "index_watches_on_movie_id"
+    t.index ["user_id", "movie_id"], name: "index_watches_on_user_id_and_movie_id", unique: true
     t.index ["user_id"], name: "index_watches_on_user_id"
   end
 


### PR DESCRIPTION
## issue 番号
close #57 

## 実装内容
- 動画教材一覧ページ
  - containerの最大幅を修正
 
## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）
- 修正前
<img width="2030" alt="スクリーンショット 2021-07-07 0 43 20" src="https://user-images.githubusercontent.com/77927517/124629381-59fe7b80-debc-11eb-998a-a3142a093b12.png">

- 修正後
<img width="2027" alt="スクリーンショット 2021-07-07 0 24 07" src="https://user-images.githubusercontent.com/77927517/124630039-fcb6fa00-debc-11eb-87c3-bad10cd63891.png">

## 備考（必要があれば）
- 修正前は横幅を広げるとcontainerも広がり動画教材のタイトルが見えなくなってしまっておりました。