### PR TITLE
テキスト教材　検索機能

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -146,3 +146,11 @@ a:hover {
     }
   }
 }
+
+// FontAwesome 検索アイコン
+.fa_search{
+  font-family: "Font Awesome 5 Free";
+  font-style: normal;
+  font-weight: 900;
+  text-decoration: inherit;
+}

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,10 +1,12 @@
 class TextsController < ApplicationController
+
   def index
-    @texts = Text.recent.includes(:reads)
+    @q = Text.ransack(params[:q])
+    @texts = @q.result.recent.includes(:reads)
   end
 
   def show
     @text = Text.find(params[:id])
   end
-  
+
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -30,4 +30,6 @@ class Text < ApplicationRecord
     talk: 14, # 全ての勉強会
     live: 15, # 勉強会
   }
+
+  scope :recent, -> { where(genre: ["basic", "git", "ruby", "rails"]).order(id: :asc) }
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -6,7 +6,7 @@
     <%= search_form_for @q do |f| %>
       <div class="col-2.5 align-self-center">
         <div class="form-group mx-sm-3 mb-2">
-          <%= f.search_field :title_cont, class: "form-control", placeholder: "🔍教材を探す" %>
+          <%= f.search_field :title_cont, class: "form-control fa_search", placeholder: "\uf002 教材を探す" %>
         </div>
       </div>
       <table>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -19,4 +19,5 @@
     </form>
     <hr>
     <%= render 'texts/text', text: @text %>
+    <%= paginate @texts %>
 </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,4 +1,22 @@
-<div class="contents-title text-center">
-  <h3>Ruby/Rails テキスト</h3>
+<div class="base-container mw-xl">
+  <div class="contents-title text-center">
+    <h3>Ruby/Rails テキスト</h3>
+  </div>
+  <form class="form-inline justify-content-center">
+      <%= search_form_for @q do |f| %>
+        <div class="col-2.5 align-self-center">
+          <div class="form-group mx-sm-3 mb-2">
+            <%= f.search_field :title_cont, class: "form-control fa_search", placeholder: "\uf002 教材を探す" %>
+          </div>
+        </div>
+        <table>
+          <tr>
+            <td><%= f.submit "検索", class: "btn btn-primary mb-2" %></td>
+            <td><%= link_to "戻る", :back, class: "btn btn-secondary mb-2" %></td>
+          </tr>
+        </table>
+      <% end %>
+    </form>
+    <hr>
+    <%= render 'texts/text', text: @text %>
 </div>
-<%= render 'texts/text', text: @text %>


### PR DESCRIPTION
## issue 番号

close #42 


## 実装内容

- テキスト教材　検索機能
  - 検索フォームにFontAwesome使用
 

## 参考資料

- 検索フォームにFontAwesome
  - [Rails5で検索ボックスのplaceholderにFontAwesome5のアイコンを表示したい!](https://qiita.com/AmaiOmikan/items/5f8883e02fb5a20cf87d)
  - [ransackを用いて動画教材の検索機能を実装 #52](https://github.com/yanbaru-expert/team_project_48/pull/52)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

